### PR TITLE
refactor: rename package from org-node-ui to org-node-ui-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# org-node-ui
+# org-node-ui-lite
 
 A lightweight graph browser for [org-node](https://github.com/meedstrom/org-node) /
 [org-mem](https://github.com/meedstrom/org-mem) users.
@@ -40,8 +40,8 @@ Add to `init.el`:
 
 ```elisp
 (add-to-list 'load-path "/path/to/org-node-ui-lite")
-(require 'org-node-ui)
-(org-node-ui-mode +1)
+(require 'org-node-ui-lite)
+(org-node-ui-lite-mode +1)
 ```
 
 Open <http://localhost:5174/index.html>.
@@ -51,21 +51,21 @@ Open <http://localhost:5174/index.html>.
 ```elisp
 ;; Example with straight.el
 (straight-use-package
- '(org-node-ui :host github :repo "yewton/org-node-ui-lite"
-               :files ("org-node-ui.el" "packages/frontend/dist")))
+ '(org-node-ui-lite :host github :repo "yewton/org-node-ui-lite"
+                    :files ("org-node-ui-lite.el" "packages/frontend/dist")))
 
-(require 'org-node-ui)
-(org-node-ui-mode +1)
+(require 'org-node-ui-lite)
+(org-node-ui-lite-mode +1)
 ```
 
 ## Configuration
 
 ```elisp
 ;; TCP port (default: 5174)
-(setq org-node-ui-port 5174)
+(setq org-node-ui-lite-port 5174)
 
 ;; Set to nil to suppress the automatic browser open on startup
-(setq org-node-ui-open-on-start t)
+(setq org-node-ui-lite-open-on-start t)
 
 ;; Enable text caching for faster node content retrieval
 (setq org-mem-do-cache-text t)

--- a/org-node-ui-lite.el
+++ b/org-node-ui-lite.el
@@ -1,4 +1,4 @@
-;;; org-node-ui.el --- Lightweight HTTP backend for org-node graph UI  -*- lexical-binding: t; -*-
+;;; org-node-ui-lite.el --- Lightweight HTTP backend for org-node graph UI  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025, 2026  yewton
 ;;
@@ -13,7 +13,7 @@
 ;; This file is NOT part of GNU Emacs.
 
 ;;; Commentary:
-;; HTTP server that exposes org-mem node data as JSON for the org-node-ui
+;; HTTP server that exposes org-mem node data as JSON for the org-node-ui-lite
 ;; front-end (compiled to packages/frontend/dist/).
 ;;
 ;; ENDPOINTS
@@ -23,11 +23,11 @@
 ;;
 ;; QUICK START
 ;;   In init.el:
-;;     (add-to-list 'load-path "/path/to/org-node-ui")
-;;     (require 'org-node-ui)
-;;     (org-node-ui-mode +1)
+;;     (add-to-list 'load-path "/path/to/org-node-ui-lite")
+;;     (require 'org-node-ui-lite)
+;;     (org-node-ui-lite-mode +1)
 ;;
-;;   On first run, org-node-ui-mode checks whether the front-end has been
+;;   On first run, org-node-ui-lite-mode checks whether the front-end has been
 ;;   built.  If `npm' is available it runs `npm install && npm run build'
 ;;   automatically (in the background) and opens the browser when done.
 ;;   If `npm' is not found, a user-error is raised with manual instructions.
@@ -42,32 +42,32 @@
 
 ;;;; Customization
 
-(defgroup org-node-ui nil
-  "Serve org-mem graph data to the org-node-ui front-end."
+(defgroup org-node-ui-lite nil
+  "Serve org-mem graph data to the org-node-ui-lite front-end."
   :group 'applications)
 
-(defcustom org-node-ui-port 5174
+(defcustom org-node-ui-lite-port 5174
   "TCP port for the HTTP server."
   :type 'integer
-  :group 'org-node-ui)
+  :group 'org-node-ui-lite)
 
-(defcustom org-node-ui-open-on-start t
-  "Open a browser window when `org-node-ui-mode' is enabled."
+(defcustom org-node-ui-lite-open-on-start t
+  "Open a browser window when `org-node-ui-lite-mode' is enabled."
   :type 'boolean
-  :group 'org-node-ui)
+  :group 'org-node-ui-lite)
 
-(defcustom org-node-ui-browser-function #'browse-url
+(defcustom org-node-ui-lite-browser-function #'browse-url
   "Function called with a URL string to open the UI in a browser."
   :type 'function
-  :group 'org-node-ui)
+  :group 'org-node-ui-lite)
 
-(defconst org-node-ui--this-file
+(defconst org-node-ui-lite--this-file
   (or load-file-name buffer-file-name)
   "Absolute path to this file at load time.")
 
 ;;;; Data helpers
 
-(defun org-node-ui--all-nodes ()
+(defun org-node-ui-lite--all-nodes ()
   "Return ((id . ID) (title . TITLE)) alists for every visible ID-node.
 Visibility is determined by `org-node-filter-fn', the same predicate
 org-node uses for its completion interface."
@@ -76,7 +76,7 @@ org-node uses for its completion interface."
               (title . ,(org-mem-entry-title entry))))
           (org-node-all-filtered-nodes)))
 
-(defun org-node-ui--all-edges ()
+(defun org-node-ui-lite--all-edges ()
   "Return ((source . SRC-ID) (dest . DEST-ID)) alists for all ID-links."
   (let (result)
     (dolist (link (org-mem-all-id-links))
@@ -85,7 +85,7 @@ org-node uses for its completion interface."
         (push `((source . ,src) (dest . ,dst)) result)))
     result))
 
-(defun org-node-ui--entry-raw (entry)
+(defun org-node-ui-lite--entry-raw (entry)
   "Return the raw Org file text for ENTRY.
 Uses `org-mem-entry-text' when text caching is enabled; otherwise reads
 the full file from disk."
@@ -96,7 +96,7 @@ the full file from disk."
       (insert-file-contents (org-mem-entry-file entry))
       (buffer-string))))
 
-(defun org-node-ui--backlinks (id)
+(defun org-node-ui-lite--backlinks (id)
   "Return ((source . SRC-ID) (title . TITLE)) alists for backlinks to ID."
   (let (result)
     (dolist (link (org-mem-id-links-to-id id))
@@ -107,7 +107,7 @@ the full file from disk."
               result)))
     result))
 
-(defun org-node-ui--base64url-decode (str)
+(defun org-node-ui-lite--base64url-decode (str)
   "Decode a Base64url-encoded string STR to plain text."
   (let* ((b64 (replace-regexp-in-string
                "_" "/" (replace-regexp-in-string "-" "+" str)))
@@ -121,7 +121,7 @@ the full file from disk."
 ;; current buffer for the response body and sets `httpd--header-sent', which
 ;; prevents `with-httpd-buffer' from sending a duplicate response.
 
-(defun org-node-ui--send-json (proc data &optional status)
+(defun org-node-ui-lite--send-json (proc data &optional status)
   "Respond to PROC with DATA encoded as JSON and STATUS (default 200)."
   (erase-buffer)
   (insert (json-encode data))
@@ -131,10 +131,10 @@ the full file from disk."
 ;;;; Servlets
 
 (defservlet* api/graph.json text/plain ()
-  (org-node-ui--send-json
+  (org-node-ui-lite--send-json
    httpd-current-proc
-   `((nodes . ,(vconcat (org-node-ui--all-nodes)))
-     (edges . ,(vconcat (org-node-ui--all-edges))))))
+   `((nodes . ,(vconcat (org-node-ui-lite--all-nodes)))
+     (edges . ,(vconcat (org-node-ui-lite--all-edges))))))
 
 ;; Unified handler for /api/node/:id.json and /api/node/:id/:path.
 ;; simple-httpd dispatches on the longest fixed prefix (/api/node/), so
@@ -151,106 +151,106 @@ the full file from disk."
       (let* ((node-id (file-name-sans-extension id-raw))
              (entry   (org-mem-entry-by-id node-id)))
         (if (null entry)
-            (org-node-ui--send-json proc '((error . "not_found")) 404)
-          (org-node-ui--send-json
+            (org-node-ui-lite--send-json proc '((error . "not_found")) 404)
+          (org-node-ui-lite--send-json
            proc
            `((id        . ,node-id)
              (title     . ,(org-mem-entry-title entry))
-             (raw       . ,(org-node-ui--entry-raw entry))
-             (backlinks . ,(vconcat (org-node-ui--backlinks node-id))))))))
+             (raw       . ,(org-node-ui-lite--entry-raw entry))
+             (backlinks . ,(vconcat (org-node-ui-lite--backlinks node-id))))))))
      ;; /api/node/:id/:path  (4 path components, Base64url-encoded filename)
      ((and id-raw asset)
       (let* ((entry (org-mem-entry-by-id id-raw)))
         (if (null entry)
-            (org-node-ui--send-json proc '((error . "not_found")) 404)
+            (org-node-ui-lite--send-json proc '((error . "not_found")) 404)
           (let* ((dir      (file-name-directory (org-mem-entry-file entry)))
                  (ext      (file-name-extension asset t))
                  (b64url   (file-name-sans-extension asset))
-                 (filename (org-node-ui--base64url-decode b64url))
+                 (filename (org-node-ui-lite--base64url-decode b64url))
                  (full     (expand-file-name (concat filename ext) dir)))
             (if (file-exists-p full)
                 ;; httpd-send-file calls httpd-discard-buffer, which sets
                 ;; httpd--header-sent=t and prevents a double response.
                 (httpd-send-file proc full)
-              (org-node-ui--send-json proc '((error . "not_found")) 404))))))
+              (org-node-ui-lite--send-json proc '((error . "not_found")) 404))))))
      (t
-      (org-node-ui--send-json proc '((error . "not_found")) 404)))))
+      (org-node-ui-lite--send-json proc '((error . "not_found")) 404)))))
 
 ;;;; Setup helpers
 
-(defvar org-node-ui--build-process nil
+(defvar org-node-ui-lite--build-process nil
   "Live `npm run build' process, or nil when no build is in progress.")
 
-(defun org-node-ui--dist-p ()
+(defun org-node-ui-lite--dist-p ()
   "Return non-nil when the compiled front-end exists."
   (file-exists-p
    (expand-file-name "packages/frontend/dist/index.html"
-                     (file-name-directory org-node-ui--this-file))))
+                     (file-name-directory org-node-ui-lite--this-file))))
 
-(defun org-node-ui--check-prerequisites ()
+(defun org-node-ui-lite--check-prerequisites ()
   "Warn about soft issues; signal `user-error' for hard failures."
   (unless (bound-and-true-p org-mem-updater-mode)
-    (message (concat "org-node-ui: warning: `org-mem-updater-mode' is not active. "
+    (message (concat "org-node-ui-lite: warning: `org-mem-updater-mode' is not active. "
                      "Node data may be stale. Consider adding "
                      "(org-mem-updater-mode +1) to your init.el."))))
 
-(defun org-node-ui--start-server ()
+(defun org-node-ui-lite--start-server ()
   "Configure httpd and open the browser.  Called after prerequisites pass."
-  (setq httpd-port org-node-ui-port
+  (setq httpd-port org-node-ui-lite-port
         httpd-root (expand-file-name "packages/frontend/dist/"
-                                     (file-name-directory org-node-ui--this-file)))
+                                     (file-name-directory org-node-ui-lite--this-file)))
   (httpd-start)
-  (when org-node-ui-open-on-start
-    (funcall org-node-ui-browser-function
-             (format "http://localhost:%d/index.html" org-node-ui-port)))
-  (message "org-node-ui: http://localhost:%d/index.html" org-node-ui-port))
+  (when org-node-ui-lite-open-on-start
+    (funcall org-node-ui-lite-browser-function
+             (format "http://localhost:%d/index.html" org-node-ui-lite-port)))
+  (message "org-node-ui-lite: http://localhost:%d/index.html" org-node-ui-lite-port))
 
 ;;;; Minor mode
 
 ;;;###autoload
-(define-minor-mode org-node-ui-mode
-  "Global minor mode that serves the org-node-ui graph browser.
+(define-minor-mode org-node-ui-lite-mode
+  "Global minor mode that serves the org-node-ui-lite graph browser.
 
 On first enable, checks whether the front-end has been compiled.
 If the `dist/' directory is missing and `npm' is available the build
 runs automatically in the background.  When `npm' cannot be found a
 `user-error' is raised with manual build instructions."
   :global t
-  :group 'org-node-ui
+  :group 'org-node-ui-lite
   (cond
-   (org-node-ui-mode
+   (org-node-ui-lite-mode
     ;; Abort any stale build from a previous enable attempt.
-    (when (process-live-p org-node-ui--build-process)
-      (kill-process org-node-ui--build-process)
-      (setq org-node-ui--build-process nil))
+    (when (process-live-p org-node-ui-lite--build-process)
+      (kill-process org-node-ui-lite--build-process)
+      (setq org-node-ui-lite--build-process nil))
     (condition-case err
         (progn
-          (org-node-ui--check-prerequisites)
-          (if (org-node-ui--dist-p)
-              (org-node-ui--start-server)
+          (org-node-ui-lite--check-prerequisites)
+          (if (org-node-ui-lite--dist-p)
+              (org-node-ui-lite--start-server)
             ;; Front-end not built yet — try to build it automatically.
-            (let* ((root (file-name-directory org-node-ui--this-file))
+            (let* ((root (file-name-directory org-node-ui-lite--this-file))
                    (npm  (executable-find "npm")))
               (if npm
-                  (org-node-ui--build-and-start npm root)
+                  (org-node-ui-lite--build-and-start npm root)
                 (user-error
-                 "org-node-ui: front-end not built and `npm' not found; \
+                 "org-node-ui-lite: front-end not built and `npm' not found; \
 build manually: cd %s && npm install && npm run build"
                  root)))))
       (error
-       (org-node-ui-mode -1)
+       (org-node-ui-lite-mode -1)
        (signal (car err) (cdr err)))))
    (t
-    (when (process-live-p org-node-ui--build-process)
-      (kill-process org-node-ui--build-process)
-      (setq org-node-ui--build-process nil))
+    (when (process-live-p org-node-ui-lite--build-process)
+      (kill-process org-node-ui-lite--build-process)
+      (setq org-node-ui-lite--build-process nil))
     (httpd-stop)
-    (message "org-node-ui stopped"))))
+    (message "org-node-ui-lite stopped"))))
 
-(defun org-node-ui--build-and-start (npm repo-root)
+(defun org-node-ui-lite--build-and-start (npm repo-root)
   "Run npm install (if needed) and npm run build asynchronously.
 NPM is the absolute path to the npm executable.  REPO-ROOT is the
-top-level directory of the org-node-ui checkout.
+top-level directory of the org-node-ui-lite checkout.
 On success the HTTP server is started; on failure the mode is disabled
 and the build output is shown."
   (let* ((has-modules (file-directory-p
@@ -260,30 +260,30 @@ and the build output is shown."
                      (format "%s --prefix packages/frontend run build" npm*)
                    (format "%s install && %s --prefix packages/frontend run build"
                            npm* npm*)))
-         (buf (get-buffer-create "*org-node-ui-build*")))
+         (buf (get-buffer-create "*org-node-ui-lite-build*")))
     (with-current-buffer buf (erase-buffer))
-    (message "org-node-ui: %s front-end (this may take a minute)…"
+    (message "org-node-ui-lite: %s front-end (this may take a minute)…"
              (if has-modules "Building" "Installing dependencies and building"))
-    (setq org-node-ui--build-process
+    (setq org-node-ui-lite--build-process
           (let ((default-directory repo-root))
             (make-process
-             :name "org-node-ui-build"
+             :name "org-node-ui-lite-build"
              :buffer buf
              :noquery t
              :command (list shell-file-name shell-command-switch sh-cmd)
              :sentinel
              (lambda (_proc event)
-               (setq org-node-ui--build-process nil)
+               (setq org-node-ui-lite--build-process nil)
                (if (string-match-p "finished" event)
                    (progn
-                     (message "org-node-ui: Build complete.")
+                     (message "org-node-ui-lite: Build complete.")
                      ;; Only start if the user hasn't disabled the mode meanwhile.
-                     (when org-node-ui-mode
-                       (org-node-ui--start-server)))
-                 (org-node-ui-mode -1)
-                 (display-buffer (get-buffer "*org-node-ui-build*"))
-                 (message (concat "org-node-ui: Build failed — "
-                                  "see buffer *org-node-ui-build*")))))))))
+                     (when org-node-ui-lite-mode
+                       (org-node-ui-lite--start-server)))
+                 (org-node-ui-lite-mode -1)
+                 (display-buffer (get-buffer "*org-node-ui-lite-build*"))
+                 (message (concat "org-node-ui-lite: Build failed — "
+                                  "see buffer *org-node-ui-lite-build*")))))))))
 
-(provide 'org-node-ui)
-;;; org-node-ui.el ends here
+(provide 'org-node-ui-lite)
+;;; org-node-ui-lite.el ends here

--- a/test/org-node-ui-lite-test.el
+++ b/test/org-node-ui-lite-test.el
@@ -1,72 +1,72 @@
-;;; org-node-ui-test.el --- ERT tests for org-node-ui  -*- lexical-binding: t; -*-
+;;; org-node-ui-lite-test.el --- ERT tests for org-node-ui-lite  -*- lexical-binding: t; -*-
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;;; Code:
 
 (require 'ert)
-(require 'org-node-ui)
+(require 'org-node-ui-lite)
 
-;;;; org-node-ui--base64url-decode
+;;;; org-node-ui-lite--base64url-decode
 
-(ert-deftest org-node-ui--base64url-decode/one-padding-char ()
-  (should (string= "hello" (org-node-ui--base64url-decode "aGVsbG8"))))
+(ert-deftest org-node-ui-lite--base64url-decode/one-padding-char ()
+  (should (string= "hello" (org-node-ui-lite--base64url-decode "aGVsbG8"))))
 
-(ert-deftest org-node-ui--base64url-decode/two-padding-chars ()
-  (should (string= "test" (org-node-ui--base64url-decode "dGVzdA"))))
+(ert-deftest org-node-ui-lite--base64url-decode/two-padding-chars ()
+  (should (string= "test" (org-node-ui-lite--base64url-decode "dGVzdA"))))
 
-(ert-deftest org-node-ui--base64url-decode/url-safe-minus ()
-  (should (string= "~~~" (org-node-ui--base64url-decode "fn5-"))))
+(ert-deftest org-node-ui-lite--base64url-decode/url-safe-minus ()
+  (should (string= "~~~" (org-node-ui-lite--base64url-decode "fn5-"))))
 
-(ert-deftest org-node-ui--base64url-decode/longer-string ()
-  (should (string= "diagram" (org-node-ui--base64url-decode "ZGlhZ3JhbQ"))))
+(ert-deftest org-node-ui-lite--base64url-decode/longer-string ()
+  (should (string= "diagram" (org-node-ui-lite--base64url-decode "ZGlhZ3JhbQ"))))
 
-;;;; org-node-ui--all-nodes
+;;;; org-node-ui-lite--all-nodes
 ;;
 ;; org-mem-entry has :title-maybe (not :title); org-mem-entry-title is a
 ;; separate function (not a struct accessor) that reads title-maybe.
 ;; Only mock the list-returning function; use real struct instances.
 
-(ert-deftest org-node-ui--all-nodes/maps-to-id-title-alists ()
+(ert-deftest org-node-ui-lite--all-nodes/maps-to-id-title-alists ()
   (let ((e1 (make-org-mem-entry :id "id1" :title-maybe "Alpha"))
         (e2 (make-org-mem-entry :id "id2" :title-maybe "Beta")))
     (cl-letf (((symbol-function 'org-node-all-filtered-nodes)
                (lambda () (list e1 e2))))
-      (let ((result (org-node-ui--all-nodes)))
+      (let ((result (org-node-ui-lite--all-nodes)))
         (should (= 2 (length result)))
         (should (string= "id1"   (alist-get 'id    (nth 0 result))))
         (should (string= "Alpha" (alist-get 'title (nth 0 result))))
         (should (string= "id2"   (alist-get 'id    (nth 1 result))))
         (should (string= "Beta"  (alist-get 'title (nth 1 result))))))))
 
-(ert-deftest org-node-ui--all-nodes/empty-when-no-nodes ()
+(ert-deftest org-node-ui-lite--all-nodes/empty-when-no-nodes ()
   (cl-letf (((symbol-function 'org-node-all-filtered-nodes) (lambda () nil)))
-    (should (null (org-node-ui--all-nodes)))))
+    (should (null (org-node-ui-lite--all-nodes)))))
 
-;;;; org-node-ui--all-edges
+;;;; org-node-ui-lite--all-edges
 
-(ert-deftest org-node-ui--all-edges/maps-links-to-source-dest-alists ()
+(ert-deftest org-node-ui-lite--all-edges/maps-links-to-source-dest-alists ()
   (let ((link (make-org-mem-link :nearby-id "s1" :target "d1")))
     (cl-letf (((symbol-function 'org-mem-all-id-links)
                (lambda () (list link))))
-      (let ((result (org-node-ui--all-edges)))
+      (let ((result (org-node-ui-lite--all-edges)))
         (should (= 1 (length result)))
         (should (string= "s1" (alist-get 'source (car result))))
         (should (string= "d1" (alist-get 'dest   (car result))))))))
 
-(ert-deftest org-node-ui--all-edges/skips-links-without-nearby-id ()
+(ert-deftest org-node-ui-lite--all-edges/skips-links-without-nearby-id ()
   (let ((link1 (make-org-mem-link :nearby-id nil  :target "d1"))
         (link2 (make-org-mem-link :nearby-id "s2" :target "d2")))
     (cl-letf (((symbol-function 'org-mem-all-id-links)
                (lambda () (list link1 link2))))
-      (let ((result (org-node-ui--all-edges)))
+      (let ((result (org-node-ui-lite--all-edges)))
         (should (= 1 (length result)))
         (should (string= "s2" (alist-get 'source (car result))))
         (should (string= "d2" (alist-get 'dest   (car result))))))))
 
-;;;; org-node-ui--backlinks
+;;;; org-node-ui-lite--backlinks
 
-(ert-deftest org-node-ui--backlinks/returns-source-id-and-title ()
+(ert-deftest org-node-ui-lite--backlinks/returns-source-id-and-title ()
   (let ((entry1 (make-org-mem-entry :id "src1" :title-maybe "Title:src1"))
         (entry2 (make-org-mem-entry :id "src2" :title-maybe "Title:src2"))
         (link1  (make-org-mem-link :nearby-id "src1"))
@@ -77,14 +77,14 @@
                (lambda (id)
                  (cond ((string= id "src1") entry1)
                        ((string= id "src2") entry2)))))
-      (let ((result (org-node-ui--backlinks "target")))
+      (let ((result (org-node-ui-lite--backlinks "target")))
         (should (= 2 (length result)))
         ;; dolist+push reverses order; src2 ends up first
         (should (string= "src2"       (alist-get 'source (nth 0 result))))
         (should (string= "Title:src2" (alist-get 'title  (nth 0 result))))
         (should (string= "src1"       (alist-get 'source (nth 1 result))))))))
 
-(ert-deftest org-node-ui--backlinks/skips-links-whose-source-entry-is-missing ()
+(ert-deftest org-node-ui-lite--backlinks/skips-links-whose-source-entry-is-missing ()
   (let ((real-entry (make-org-mem-entry :id "real" :title-maybe "Real Node"))
         (ghost-link (make-org-mem-link :nearby-id "ghost"))
         (real-link  (make-org-mem-link :nearby-id "real")))
@@ -92,24 +92,24 @@
                (lambda (_id) (list ghost-link real-link)))
               ((symbol-function 'org-mem-entry-by-id)
                (lambda (id) (when (string= id "real") real-entry))))
-      (let ((result (org-node-ui--backlinks "target")))
+      (let ((result (org-node-ui-lite--backlinks "target")))
         (should (= 1 (length result)))
         (should (string= "real"      (alist-get 'source (car result))))
         (should (string= "Real Node" (alist-get 'title  (car result))))))))
 
-;;;; org-node-ui--entry-raw
+;;;; org-node-ui-lite--entry-raw
 ;;
 ;; org-mem-entry-text and org-mem-entry-file are regular functions (not struct
-;; accessors), so cl-letf can mock them even when org-node-ui.el is compiled.
+;; accessors), so cl-letf can mock them even when org-node-ui-lite.el is compiled.
 
-(ert-deftest org-node-ui--entry-raw/returns-cached-text-when-available ()
+(ert-deftest org-node-ui-lite--entry-raw/returns-cached-text-when-available ()
   (cl-letf (((symbol-function 'org-mem-entry-text) (lambda (_e) "* Cached\n")))
     (let ((entry (make-org-mem-entry))
           (org-mem-do-cache-text t))
-      (should (string= "* Cached\n" (org-node-ui--entry-raw entry))))))
+      (should (string= "* Cached\n" (org-node-ui-lite--entry-raw entry))))))
 
-(ert-deftest org-node-ui--entry-raw/reads-file-when-cache-disabled ()
-  (let ((tmpfile (make-temp-file "org-node-ui-test-" nil ".org")))
+(ert-deftest org-node-ui-lite--entry-raw/reads-file-when-cache-disabled ()
+  (let ((tmpfile (make-temp-file "org-node-ui-lite-test-" nil ".org")))
     (unwind-protect
         (progn
           (with-temp-file tmpfile (insert "* From file\n"))
@@ -117,20 +117,20 @@
             (let ((entry (make-org-mem-entry))
                   (org-mem-do-cache-text nil))
               (should (string= "* From file\n"
-                               (org-node-ui--entry-raw entry))))))
+                               (org-node-ui-lite--entry-raw entry))))))
       (delete-file tmpfile))))
 
-;;;; org-node-ui--build-and-start
+;;;; org-node-ui-lite--build-and-start
 
-(ert-deftest org-node-ui--build-and-start/process-runs-in-repo-root ()
+(ert-deftest org-node-ui-lite--build-and-start/process-runs-in-repo-root ()
   "npm process must start in repo-root regardless of the caller's directory."
   (let (proc-dir)
     (cl-letf (((symbol-function 'make-process)
                (lambda (&rest _) (setq proc-dir default-directory) nil))
               ((symbol-function 'file-directory-p) (lambda (_) nil)))
       (let ((default-directory "/unrelated/"))
-        (org-node-ui--build-and-start "/usr/bin/npm" "/repo/root/")))
+        (org-node-ui-lite--build-and-start "/usr/bin/npm" "/repo/root/")))
     (should (string= "/repo/root/" proc-dir))))
 
-(provide 'org-node-ui-test)
-;;; org-node-ui-test.el ends here
+(provide 'org-node-ui-lite-test)
+;;; org-node-ui-lite-test.el ends here


### PR DESCRIPTION
## Summary

- Rename `org-node-ui.el` to `org-node-ui-lite.el` (via `git mv`)
- Rename `test/org-node-ui-test.el` to `test/org-node-ui-lite-test.el`
- Update all symbols, `provide`/`require` forms, group names, and message strings to use `org-node-ui-lite`
- Update README title and code examples accordingly

Aligns the Emacs package name with the repository name and its upstream reference (org-roam-ui-lite).

## Test plan

- [x] `eldev --packaged --warnings-as-errors compile` — no warnings
- [x] `eldev test` — 13/13 passed
- [x] `npm run lint` — clean
- [x] `npm run check` — passed
- [x] `npm test` — 179/179 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)