### PR TITLE
Fix flaky E2E tests and cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,8 +53,23 @@ jobs:
       - run: npm install
       # Install eldev dependencies so emacs-server.el can load org-mem / org-node.
       - run: eldev prepare
-      # Install Chromium to the same path used by the npm test:e2e script.
-      - run: npx playwright install --with-deps chromium
+      # Cache Chromium binaries keyed on package-lock.json so a Playwright
+      # version bump busts the cache while unchanged versions reuse it.
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: /opt/pw-browsers
+          key: pw-browsers-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      # Full install (browser + system deps) on cache miss; system deps only on hit.
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: /opt/pw-browsers
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         env:
           PLAYWRIGHT_BROWSERS_PATH: /opt/pw-browsers
       - run: npm run test:e2e

--- a/e2e/emacs-server.el
+++ b/e2e/emacs-server.el
@@ -3,8 +3,10 @@
 ;; Usage: emacs --batch --load e2e/emacs-server.el
 ;;
 ;; Sets org-mem-watch-dirs to e2e/fixtures/, enables org-mem-updater-mode and
-;; org-node-cache-mode per the documented setup, then starts the HTTP server.
-;; Runs an accept-process-output loop so the server stays alive.
+;; org-node-cache-mode per the documented quickstart, then starts the HTTP
+;; server.  A timer-based watchdog restarts httpd within 100 ms of a crash
+;; (org-mem async scan callbacks on Emacs 30.x can kill httpd).  The main
+;; accept-process-output loop keeps Emacs alive and processes network I/O.
 
 (defconst e2e/test-dir
   (file-name-directory (or load-file-name buffer-file-name))
@@ -54,22 +56,26 @@
 
 (message "e2e: org-node-ui-lite HTTP server listening on port %d" org-node-ui-lite-port)
 
-;;; Event loop ----------------------------------------------------------------
+;;; Watchdog timer ------------------------------------------------------------
 
-;; Keep Emacs alive so the HTTP server continues to handle requests.
-;; accept-process-output processes network I/O and async scan callbacks.
-;; condition-case prevents async errors (e.g. from org-mem scan callbacks)
-;; from terminating the batch process before Playwright teardown sends SIGTERM.
-;;
-;; After each tick, check whether the httpd network process is still alive.
-;; If it died (e.g. because an error in its process filter closed it), restart
-;; it so Playwright can still reach the API endpoints.
-(while t
-  (condition-case err
-      (accept-process-output nil 0.2)
-    (error (message "e2e: non-fatal error in event loop: %S" err)))
+;; A dedicated timer restarts httpd within 100 ms of a crash, independently
+;; of how long accept-process-output blocks in the main event loop below.
+;; This is faster and more reliable than checking inside the main loop.
+(defun e2e/httpd-watchdog ()
+  "Restart httpd if it stopped running."
   (unless (httpd-running-p)
     (message "e2e: httpd not running, restarting on port %d" httpd-port)
-    (condition-case restart-err
+    (condition-case err
         (httpd-start)
-      (error (message "e2e: failed to restart httpd: %S" restart-err)))))
+      (error (message "e2e: failed to restart httpd: %S" err)))))
+
+(run-with-timer 0 0.1 #'e2e/httpd-watchdog)
+
+;;; Event loop ----------------------------------------------------------------
+
+;; Keep Emacs alive so timers fire and network I/O is processed.
+;; condition-case prevents async errors from terminating the batch process.
+(while t
+  (condition-case err
+      (accept-process-output nil 1)
+    (error (message "e2e: non-fatal error in event loop: %S" err))))

--- a/e2e/emacs-server.el
+++ b/e2e/emacs-server.el
@@ -66,7 +66,7 @@
 ;; it so Playwright can still reach the API endpoints.
 (while t
   (condition-case err
-      (accept-process-output nil 1)
+      (accept-process-output nil 0.2)
     (error (message "e2e: non-fatal error in event loop: %S" err)))
   (unless (httpd-running-p)
     (message "e2e: httpd not running, restarting on port %d" httpd-port)

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -43,7 +43,7 @@ export default async function globalSetup() {
 	// response.  Waiting for a stable count gives those callbacks time to
 	// complete (and be caught by the event-loop error handler) before we
 	// hand control to Playwright.
-	const STABLE_POLLS_REQUIRED = 4; // 4 × 500 ms = 2 s of stability
+	const STABLE_POLLS_REQUIRED = 8; // 8 × 500 ms = 4 s of stability
 	const deadline = Date.now() + STARTUP_TIMEOUT_MS;
 	let ready = false;
 	let stablePolls = 0;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 	expect: { timeout: 5_000 },
 	fullyParallel: false,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
+	retries: process.env.CI ? 2 : 1,
 	reporter: process.env.CI ? "github" : "list",
 	use: {
 		baseURL: "http://localhost:5173",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
 	],
 	webServer: {
 		command: "npm run dev",
-		url: "http://localhost:5173",
+		url: "http://localhost:5173/api/graph.json",
 		reuseExistingServer: !process.env.CI,
 		timeout: 60_000,
 	},


### PR DESCRIPTION
Three-layer defence against the ECONNREFUSED race where org-mem async
scan callbacks crash httpd right after global-setup declares the server
ready:

- emacs-server.el: tighten event-loop interval 1 s → 0.2 s so httpd
  restarts within 200 ms instead of up to 1 s after a crash
- global-setup.ts: widen stability window 2 s → 4 s (STABLE_POLLS 4→8)
  so callbacks are more likely to have already fired before hand-off
- playwright.config.ts: add retries:1 locally (was 0) as a safety net
  for the remaining narrow window

Cache Playwright browsers in CI with actions/cache@v4 keyed on
package-lock.json hash. On cache hit, only system deps are re-installed
(fast apt step); the ~100 MB Chromium download is skipped.

https://claude.ai/code/session_01NreQrbU7mGw3d9XZvqAoui