### PR TITLE
feat: Focus graph on selected node (Fix #17)

### DIFF
--- a/packages/frontend/src/graph/graph-style.ts
+++ b/packages/frontend/src/graph/graph-style.ts
@@ -114,3 +114,82 @@ export function resetHighlight(
 	graphObj.nodeColor?.("color");
 	graphObj.linkColor?.("color");
 }
+
+/**
+ * Center and zoom on a specific node.
+ *
+ * @param graph - Graph instance
+ * @param focusId - Node id to focus on
+ */
+export function focusNode(
+	graph: GraphInstance | undefined | Record<string, unknown>,
+	focusId: string,
+): void {
+	if (!graph) return;
+
+	const graphObj = graph as {
+		animate?: (opts: unknown, props: unknown) => void;
+		$id?: (id: string) => { length: number };
+		cameraPosition?: (pos: unknown, lookAt: unknown, ms: number) => void;
+		centerAt?: (x: number, y: number, ms: number) => void;
+		zoom?: (val: number, ms: number) => void;
+		graphData?: () => {
+			nodes: Array<{ id: string; x?: number; y?: number; z?: number }>;
+		};
+	};
+
+	// Cytoscape
+	if (
+		typeof graphObj.animate === "function" &&
+		typeof graphObj.$id === "function"
+	) {
+		const node = graphObj.$id(focusId);
+		if (node && node.length > 0) {
+			graphObj.animate(
+				{
+					center: { eles: node },
+					zoom: 1.5,
+				},
+				{ duration: 500 },
+			);
+		}
+		return;
+	}
+
+	// Force Graph 3D
+	if (typeof graphObj.cameraPosition === "function") {
+		const data = graphObj.graphData?.();
+		if (!data) return;
+		const node = data.nodes.find((n) => n.id === focusId);
+		if (node) {
+			// Calculate a position slightly offset from the node for a good view
+			const distance = 100;
+			const distRatio =
+				1 + distance / Math.hypot(node.x || 0, node.y || 0, node.z || 0);
+			const newPos =
+				node.x || node.y || node.z
+					? {
+							x: (node.x || 0) * distRatio,
+							y: (node.y || 0) * distRatio,
+							z: (node.z || 0) * distRatio,
+						}
+					: { x: 0, y: 0, z: distance };
+			graphObj.cameraPosition(newPos, node, 1000);
+		}
+		return;
+	}
+
+	// Force Graph 2D
+	if (
+		typeof graphObj.centerAt === "function" &&
+		typeof graphObj.zoom === "function"
+	) {
+		const data = graphObj.graphData?.();
+		if (!data) return;
+		const node = data.nodes.find((n) => n.id === focusId);
+		if (node) {
+			graphObj.centerAt(node.x || 0, node.y || 0, 1000);
+			graphObj.zoom(2, 1000);
+		}
+	}
+}

--- a/packages/frontend/src/hooks/useGraphManager.ts
+++ b/packages/frontend/src/hooks/useGraphManager.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef } from "react";
 import { destroyGraph, drawGraph } from "../graph/graph.ts";
 import {
 	applyNodeStyle,
+	focusNode,
 	highlightNeighborhood,
 	resetHighlight,
 } from "../graph/graph-style.ts";
@@ -56,6 +57,7 @@ export function useGraphManager(initialConfig: UseGraphManagerProps) {
 			dispatch({ type: "SET_STATE", payload: { selected: node } });
 			dispatch({ type: "OPEN_DETAILS" });
 			highlightNode(nodeId);
+			focusNode(graphInstanceRef.current, nodeId);
 		},
 		[dispatch, highlightNode],
 	);

--- a/packages/frontend/test/hooks/useGraphManager.test.tsx
+++ b/packages/frontend/test/hooks/useGraphManager.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../src/graph/graph.ts", () => ({
 
 vi.mock("../../src/graph/graph-style.ts", () => ({
 	applyNodeStyle: vi.fn(),
+	focusNode: vi.fn(),
 	highlightNeighborhood: vi.fn(),
 	resetHighlight: vi.fn(),
 }));


### PR DESCRIPTION
Implements issue #17 by adding a `focusNode` function that zooms in and centers on the selected node in the graph, regardless of the active renderer (Cytoscape, Force Graph 2D, or Force Graph 3D). The `openNodeAction` hook now calls `focusNode` to apply these view adjustments dynamically whenever a new node is focused. Tests and Pre-commit have run cleanly.

---
*PR created automatically by Jules for task [2890534457063551941](https://jules.google.com/task/2890534457063551941) started by @yewton*