### PR TITLE
chore: update screenshots CI behavior

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
 
   check-screenshots:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.actor != 'github-actions[bot]' && (github.event_name == 'pull_request' || github.event_name == 'push')
     outputs:
       should_run: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -108,13 +108,10 @@ jobs:
 
   screenshots:
     needs: [test, test-elisp, test-e2e, check-screenshots]
-    if: always() && github.event_name == 'pull_request' && needs.check-screenshots.outputs.should_run == 'true' && needs.test.result == 'success' && needs.test-elisp.result == 'success' && needs.test-e2e.result == 'success'
+    if: always() && needs.check-screenshots.outputs.should_run == 'true' && needs.test.result == 'success' && needs.test-elisp.result == 'success' && needs.test-e2e.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
@@ -149,14 +146,17 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
       - run: npm run screenshots
-      - name: Commit screenshots
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/screenshots/
-          if git diff --cached --quiet; then
-            echo "Screenshots unchanged, nothing to commit."
-          else
-            git commit -m "chore: update README screenshots [skip ci]"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
+      - name: Upload screenshots artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: screenshots
+          path: docs/screenshots/
+      - name: Create Pull Request for updated screenshots
+        if: github.event_name == 'push'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "chore: update README screenshots"
+          title: "chore: update README screenshots"
+          body: "Automated PR to update README screenshots."
+          branch: "bot/update-screenshots"


### PR DESCRIPTION
Modifies the GitHub Actions CI workflow to:
- Stop automatically committing updated screenshots back to a PR branch, preventing failed pushes or wiped check statuses.
- Use `actions/upload-artifact@v7` to upload screenshots on pull requests.
- Use `peter-evans/create-pull-request@v8` to automatically generate a PR on pushes to the `main` branch.
- Prevent infinite loops by skipping the action if triggered by `github-actions[bot]`.

---
*PR created automatically by Jules for task [8469811130236291188](https://jules.google.com/task/8469811130236291188) started by @yewton*