### PR TITLE
Fix GitHub Actions error when creating PR for updated screenshots

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   test:


### PR DESCRIPTION
Adds the `pull-requests: write` permission to the main workflow in `.github/workflows/test.yaml`. This fixes the "Resource not accessible by integration" error encountered when the `peter-evans/create-pull-request` action attempts to create or update a PR for updated screenshots.

---
*PR created automatically by Jules for task [15858928664918870599](https://jules.google.com/task/15858928664918870599) started by @yewton*