### PR TITLE
Add org-node-ui-lite-rebuild-frontend command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,10 @@ jobs:
           node-version: "24"
           cache: npm
       - run: npm ci
+      - name: Verify .source-hash is up to date
+        run: |
+          npm run gen-hash
+          git diff --exit-code packages/frontend/.source-hash
       - run: npm run lint
       - run: npm run check
       - run: npm test

--- a/org-node-ui-lite.el
+++ b/org-node-ui-lite.el
@@ -292,6 +292,23 @@ build manually: cd %s && npm install && npm run build"
     (httpd-stop)
     (message "org-node-ui-lite stopped"))))
 
+;;;###autoload
+(defun org-node-ui-lite-rebuild-frontend ()
+  "Rebuild the org-node-ui-lite front-end.
+This stops any ongoing build and runs `npm run build' in the
+background.  Requires `npm' to be available."
+  (interactive)
+  (when (process-live-p org-node-ui-lite--build-process)
+    (kill-process org-node-ui-lite--build-process)
+    (setq org-node-ui-lite--build-process nil))
+  (let* ((root (file-name-directory org-node-ui-lite--this-file))
+         (npm  (executable-find "npm")))
+    (if npm
+        (org-node-ui-lite--build-and-start npm root)
+      (user-error
+       "org-node-ui-lite: `npm' not found; build manually: cd %s && npm install && npm run build"
+       root))))
+
 (defun org-node-ui-lite--build-and-start (npm repo-root)
   "Run npm install (if needed) and npm run build asynchronously.
 NPM is the absolute path to the npm executable.  REPO-ROOT is the

--- a/org-node-ui-lite.el
+++ b/org-node-ui-lite.el
@@ -26,6 +26,10 @@
 ;;   M-x org-node-ui-lite-select-current
 ;;       Select the org-node at point in the WebUI regardless of follow-mode.
 ;;
+;;   M-x org-node-ui-lite-rebuild-frontend
+;;       Force a fresh rebuild of the front-end, even if dist/ already exists.
+;;       Use this after updating the codebase to avoid a stale front-end.
+;;
 ;; QUICK START
 ;;   In init.el:
 ;;     (add-to-list 'load-path "/path/to/org-node-ui-lite")
@@ -228,6 +232,26 @@ Works regardless of whether follow-mode is enabled in the browser."
    (expand-file-name "packages/frontend/dist/index.html"
                      (file-name-directory org-node-ui-lite--this-file))))
 
+(defun org-node-ui-lite--read-hash-file (path)
+  "Return the trimmed contents of the hash file at PATH, or nil if absent."
+  (when (file-readable-p path)
+    (with-temp-buffer
+      (insert-file-contents path)
+      (string-trim (buffer-string)))))
+
+(defun org-node-ui-lite--frontend-stale-p (repo-root)
+  "Return non-nil when the built front-end does not match the source hash.
+Returns nil (not stale) when REPO-ROOT lacks a `.source-hash' file, so
+older checkouts without this feature are handled gracefully."
+  (let* ((source-hash
+          (org-node-ui-lite--read-hash-file
+           (expand-file-name "packages/frontend/.source-hash" repo-root)))
+         (build-hash
+          (org-node-ui-lite--read-hash-file
+           (expand-file-name "packages/frontend/dist/.build-hash" repo-root))))
+    (and source-hash
+         (not (equal source-hash build-hash)))))
+
 (defun org-node-ui-lite--check-prerequisites ()
   "Warn about soft issues; signal `user-error' for hard failures."
   (unless (bound-and-true-p org-mem-updater-mode)
@@ -268,17 +292,29 @@ runs automatically in the background.  When `npm' cannot be found a
         (progn
           (add-hook 'post-command-hook #'org-node-ui-lite--track-current-node)
           (org-node-ui-lite--check-prerequisites)
-          (if (org-node-ui-lite--dist-p)
-              (org-node-ui-lite--start-server)
-            ;; Front-end not built yet — try to build it automatically.
-            (let* ((root (file-name-directory org-node-ui-lite--this-file))
-                   (npm  (executable-find "npm")))
+          (let* ((root (file-name-directory org-node-ui-lite--this-file))
+                 (npm  (executable-find "npm")))
+            (cond
+             ;; dist/ absent: build from scratch.
+             ((not (org-node-ui-lite--dist-p))
               (if npm
                   (org-node-ui-lite--build-and-start npm root)
                 (user-error
                  "org-node-ui-lite: front-end not built and `npm' not found; \
 build manually: cd %s && npm install && npm run build"
-                 root)))))
+                 root)))
+             ;; dist/ present but stale: rebuild.
+             ((org-node-ui-lite--frontend-stale-p root)
+              (message "org-node-ui-lite: front-end is stale — rebuilding…")
+              (if npm
+                  (org-node-ui-lite--build-and-start npm root)
+                (user-error
+                 "org-node-ui-lite: front-end is stale and `npm' not found; \
+rebuild manually: cd %s && npm install && npm run build"
+                 root)))
+             ;; dist/ present and fresh: start immediately.
+             (t
+              (org-node-ui-lite--start-server)))))
       (error
        (org-node-ui-lite-mode -1)
        (signal (car err) (cdr err)))))
@@ -291,23 +327,6 @@ build manually: cd %s && npm install && npm run build"
       (setq org-node-ui-lite--build-process nil))
     (httpd-stop)
     (message "org-node-ui-lite stopped"))))
-
-;;;###autoload
-(defun org-node-ui-lite-rebuild-frontend ()
-  "Rebuild the org-node-ui-lite front-end.
-This stops any ongoing build and runs `npm run build' in the
-background.  Requires `npm' to be available."
-  (interactive)
-  (when (process-live-p org-node-ui-lite--build-process)
-    (kill-process org-node-ui-lite--build-process)
-    (setq org-node-ui-lite--build-process nil))
-  (let* ((root (file-name-directory org-node-ui-lite--this-file))
-         (npm  (executable-find "npm")))
-    (if npm
-        (org-node-ui-lite--build-and-start npm root)
-      (user-error
-       "org-node-ui-lite: `npm' not found; build manually: cd %s && npm install && npm run build"
-       root))))
 
 (defun org-node-ui-lite--build-and-start (npm repo-root)
   "Run npm install (if needed) and npm run build asynchronously.
@@ -339,6 +358,13 @@ and the build output is shown."
                (if (string-match-p "finished" event)
                    (progn
                      (message "org-node-ui-lite: Build complete.")
+                     ;; Stamp the build so future startups can detect staleness.
+                     (condition-case nil
+                         (copy-file
+                          (expand-file-name "packages/frontend/.source-hash" repo-root)
+                          (expand-file-name "packages/frontend/dist/.build-hash" repo-root)
+                          t)
+                       (error nil))
                      ;; Only start if the user hasn't disabled the mode meanwhile.
                      (when org-node-ui-lite-mode
                        (org-node-ui-lite--start-server)))
@@ -346,6 +372,25 @@ and the build output is shown."
                  (display-buffer (get-buffer "*org-node-ui-lite-build*"))
                  (message (concat "org-node-ui-lite: Build failed — "
                                   "see buffer *org-node-ui-lite-build*")))))))))
+
+;;;###autoload
+(defun org-node-ui-lite-rebuild-frontend ()
+  "Force a fresh rebuild of the front-end, even if dist/ already exists.
+Use this after updating the codebase to avoid running a stale front-end
+alongside a newer backend.  Any in-progress build is cancelled first.
+When the build succeeds and `org-node-ui-lite-mode' is active, the HTTP
+server is restarted automatically."
+  (interactive)
+  (let* ((root (file-name-directory org-node-ui-lite--this-file))
+         (npm  (executable-find "npm")))
+    (unless npm
+      (user-error
+       "org-node-ui-lite: `npm' not found; build manually: cd %s && npm install && npm run build"
+       root))
+    (when (process-live-p org-node-ui-lite--build-process)
+      (kill-process org-node-ui-lite--build-process)
+      (setq org-node-ui-lite--build-process nil))
+    (org-node-ui-lite--build-and-start npm root)))
 
 (provide 'org-node-ui-lite)
 ;;; org-node-ui-lite.el ends here

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	"scripts": {
 		"build": "npm --workspace=packages/frontend run build",
 		"dev": "npm --workspace=packages/frontend run dev",
+		"gen-hash": "npm --workspace=packages/frontend run gen-hash",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
 		"check": "tsgo",

--- a/packages/frontend/.source-hash
+++ b/packages/frontend/.source-hash
@@ -1,0 +1,1 @@
+abca29974c886a812ac86d0bad0ebcae8eae26295efef52f1b6fd9c4106b8bda

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"gen-hash": "node scripts/gen-source-hash.mjs"
 	},
 	"dependencies": {
 		"@rehype-pretty/transformers": "^0.13.2",

--- a/packages/frontend/scripts/gen-source-hash.mjs
+++ b/packages/frontend/scripts/gen-source-hash.mjs
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+import { globSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const frontendDir = resolve(import.meta.dirname, "..");
+const outputFile = join(frontendDir, ".source-hash");
+
+const files = globSync("**", {
+	cwd: frontendDir,
+	exclude: (p) =>
+		p === "node_modules" ||
+		p.startsWith("node_modules/") ||
+		p === "dist" ||
+		p.startsWith("dist/") ||
+		p === ".source-hash",
+})
+	.filter((f) => {
+		try {
+			return statSync(join(frontendDir, f)).isFile();
+		} catch {
+			return false;
+		}
+	})
+	.sort();
+
+const outer = createHash("sha256");
+for (const rel of files) {
+	const content = readFileSync(join(frontendDir, rel));
+	const inner = createHash("sha256").update(content).digest("hex");
+	outer.update(`${rel}:${inner}\n`);
+}
+
+writeFileSync(outputFile, `${outer.digest("hex")}\n`);

--- a/test/org-node-ui-lite-test.el
+++ b/test/org-node-ui-lite-test.el
@@ -188,5 +188,22 @@
         (org-node-ui-lite--build-and-start "/usr/bin/npm" "/repo/root/")))
     (should (string= "/repo/root/" proc-dir))))
 
+;;;; org-node-ui-lite-rebuild-frontend
+
+(ert-deftest org-node-ui-lite-rebuild-frontend/calls-build-and-start ()
+  "Calls `org-node-ui-lite--build-and-start' when `npm' is available."
+  (let (called)
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (cmd) (when (string= cmd "npm") "/usr/bin/npm")))
+              ((symbol-function 'org-node-ui-lite--build-and-start)
+               (lambda (npm _root) (setq called npm))))
+      (org-node-ui-lite-rebuild-frontend)
+      (should (string= "/usr/bin/npm" called)))))
+
+(ert-deftest org-node-ui-lite-rebuild-frontend/signals-user-error-when-npm-missing ()
+  "Signals `user-error' when `npm' is not found."
+  (cl-letf (((symbol-function 'executable-find) (lambda (_) nil)))
+    (should-error (org-node-ui-lite-rebuild-frontend) :type 'user-error)))
+
 (provide 'org-node-ui-lite-test)
 ;;; org-node-ui-lite-test.el ends here

--- a/test/org-node-ui-lite-test.el
+++ b/test/org-node-ui-lite-test.el
@@ -191,19 +191,124 @@
 ;;;; org-node-ui-lite-rebuild-frontend
 
 (ert-deftest org-node-ui-lite-rebuild-frontend/calls-build-and-start ()
-  "Calls `org-node-ui-lite--build-and-start' when `npm' is available."
-  (let (called)
-    (cl-letf (((symbol-function 'executable-find)
-               (lambda (cmd) (when (string= cmd "npm") "/usr/bin/npm")))
+  "Passes npm path and repo root to --build-and-start."
+  (let (captured-npm captured-root)
+    (cl-letf (((symbol-function 'executable-find) (lambda (_) "/usr/bin/npm"))
               ((symbol-function 'org-node-ui-lite--build-and-start)
-               (lambda (npm _root) (setq called npm))))
+               (lambda (npm root)
+                 (setq captured-npm npm captured-root root))))
       (org-node-ui-lite-rebuild-frontend)
-      (should (string= "/usr/bin/npm" called)))))
+      (should (string= "/usr/bin/npm" captured-npm))
+      (should (string= (file-name-directory org-node-ui-lite--this-file)
+                       captured-root)))))
 
 (ert-deftest org-node-ui-lite-rebuild-frontend/signals-user-error-when-npm-missing ()
-  "Signals `user-error' when `npm' is not found."
+  "Raises user-error when npm is not found on PATH."
   (cl-letf (((symbol-function 'executable-find) (lambda (_) nil)))
     (should-error (org-node-ui-lite-rebuild-frontend) :type 'user-error)))
+
+(ert-deftest org-node-ui-lite-rebuild-frontend/kills-running-build-first ()
+  "Kills any in-progress build before starting a new one."
+  (let (kill-called)
+    (cl-letf (((symbol-function 'executable-find) (lambda (_) "/usr/bin/npm"))
+              ((symbol-function 'process-live-p) (lambda (_) t))
+              ((symbol-function 'kill-process) (lambda (_) (setq kill-called t)))
+              ((symbol-function 'org-node-ui-lite--build-and-start) #'ignore))
+      (let ((org-node-ui-lite--build-process 'fake-proc))
+        (org-node-ui-lite-rebuild-frontend)
+        (should kill-called)
+        (should (null org-node-ui-lite--build-process))))))
+
+;;;; org-node-ui-lite--read-hash-file
+
+(ert-deftest org-node-ui-lite--read-hash-file/returns-trimmed-content ()
+  "Returns the trimmed hash string when the file exists."
+  (let ((tmpfile (make-temp-file "org-node-ui-lite-test-hash-")))
+    (unwind-protect
+        (progn
+          (with-temp-file tmpfile (insert "abc123\n"))
+          (should (string= "abc123"
+                           (org-node-ui-lite--read-hash-file tmpfile))))
+      (delete-file tmpfile))))
+
+(ert-deftest org-node-ui-lite--read-hash-file/returns-nil-when-absent ()
+  "Returns nil when the file does not exist."
+  (should (null (org-node-ui-lite--read-hash-file
+                 "/nonexistent/path/.source-hash"))))
+
+;;;; org-node-ui-lite--frontend-stale-p
+
+(ert-deftest org-node-ui-lite--frontend-stale-p/not-stale-when-hashes-match ()
+  "Returns nil when .source-hash and dist/.build-hash contain the same digest."
+  (cl-letf (((symbol-function 'org-node-ui-lite--read-hash-file)
+             (lambda (_path) "aaa")))
+    (should (null (org-node-ui-lite--frontend-stale-p "/fake/root/")))))
+
+(ert-deftest org-node-ui-lite--frontend-stale-p/stale-when-hashes-differ ()
+  "Returns non-nil when .source-hash and dist/.build-hash contain different digests."
+  (cl-letf (((symbol-function 'org-node-ui-lite--read-hash-file)
+             (lambda (path)
+               (if (string-suffix-p ".source-hash" path) "aaa" "bbb"))))
+    (should (org-node-ui-lite--frontend-stale-p "/fake/root/"))))
+
+(ert-deftest org-node-ui-lite--frontend-stale-p/stale-when-build-hash-absent ()
+  "Returns non-nil when .source-hash exists but dist/.build-hash is absent."
+  (cl-letf (((symbol-function 'org-node-ui-lite--read-hash-file)
+             (lambda (path)
+               (when (string-suffix-p ".source-hash" path) "aaa"))))
+    (should (org-node-ui-lite--frontend-stale-p "/fake/root/"))))
+
+(ert-deftest org-node-ui-lite--frontend-stale-p/not-stale-when-source-hash-absent ()
+  "Returns nil (graceful degradation) when .source-hash is absent."
+  (cl-letf (((symbol-function 'org-node-ui-lite--read-hash-file)
+             (lambda (_path) nil)))
+    (should (null (org-node-ui-lite--frontend-stale-p "/fake/root/")))))
+
+;;;; org-node-ui-lite-mode staleness branch
+
+(ert-deftest org-node-ui-lite-mode/rebuilds-when-stale ()
+  "Triggers a build when dist/ exists but the front-end is stale."
+  (let (build-called)
+    (cl-letf (((symbol-function 'org-node-ui-lite--dist-p) (lambda () t))
+              ((symbol-function 'org-node-ui-lite--frontend-stale-p)
+               (lambda (_root) t))
+              ((symbol-function 'executable-find) (lambda (_) "/usr/bin/npm"))
+              ((symbol-function 'org-node-ui-lite--check-prerequisites) #'ignore)
+              ((symbol-function 'org-node-ui-lite--build-and-start)
+               (lambda (_npm _root) (setq build-called t)))
+              ((symbol-function 'process-live-p) (lambda (_) nil)))
+      (let ((org-node-ui-lite-mode nil))
+        (org-node-ui-lite-mode +1)
+        (should build-called)
+        (cl-letf (((symbol-function 'httpd-stop) #'ignore))
+          (org-node-ui-lite-mode -1))))))
+
+(ert-deftest org-node-ui-lite-mode/starts-directly-when-fresh ()
+  "Starts the server directly (no rebuild) when dist/ is present and hash matches."
+  (let (server-started)
+    (cl-letf (((symbol-function 'org-node-ui-lite--dist-p) (lambda () t))
+              ((symbol-function 'org-node-ui-lite--frontend-stale-p)
+               (lambda (_root) nil))
+              ((symbol-function 'org-node-ui-lite--check-prerequisites) #'ignore)
+              ((symbol-function 'org-node-ui-lite--start-server)
+               (lambda () (setq server-started t)))
+              ((symbol-function 'process-live-p) (lambda (_) nil)))
+      (let ((org-node-ui-lite-mode nil))
+        (org-node-ui-lite-mode +1)
+        (should server-started)
+        (cl-letf (((symbol-function 'httpd-stop) #'ignore))
+          (org-node-ui-lite-mode -1))))))
+
+(ert-deftest org-node-ui-lite-mode/signals-user-error-when-stale-and-npm-missing ()
+  "Raises user-error when the front-end is stale and npm is unavailable."
+  (cl-letf (((symbol-function 'org-node-ui-lite--dist-p) (lambda () t))
+            ((symbol-function 'org-node-ui-lite--frontend-stale-p)
+             (lambda (_root) t))
+            ((symbol-function 'executable-find) (lambda (_) nil))
+            ((symbol-function 'org-node-ui-lite--check-prerequisites) #'ignore)
+            ((symbol-function 'process-live-p) (lambda (_) nil)))
+    (let ((org-node-ui-lite-mode nil))
+      (should-error (org-node-ui-lite-mode +1) :type 'user-error))))
 
 (provide 'org-node-ui-lite-test)
 ;;; org-node-ui-lite-test.el ends here


### PR DESCRIPTION
Adds a command `org-node-ui-lite-rebuild-frontend` to force rebuild the frontend. This ensures the frontend stays synchronized with the backend.

---
*PR created automatically by Jules for task [9500507274439020278](https://jules.google.com/task/9500507274439020278) started by @yewton*