### PR TITLE
ci: pin GitHub Actions versions to exact SHA-1 hashes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: npm
@@ -30,13 +30,13 @@ jobs:
       matrix:
         emacs-version: ["29.4", "30.1", "30.2"]
     steps:
-      - uses: jcs090218/setup-emacs@master
+      - uses: jcs090218/setup-emacs@a5b1cbb1af335d2e7bef99c0aa6e02cdad229182 # master
         with:
           version: ${{ matrix.emacs-version }}
-      - uses: emacs-eldev/setup-eldev@v1.5
-      - uses: actions/checkout@v6.0.2
+      - uses: emacs-eldev/setup-eldev@66eef997fb15bde4364c00acd4ee459f8be9f8b4 # v1.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache Eldev dependencies
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.eldev
           key: ${{ runner.os }}-eldev-${{ matrix.emacs-version }}-${{ hashFiles('Eldev') }}
@@ -52,18 +52,18 @@ jobs:
       matrix:
         emacs-version: ["29.4", "30.1", "30.2"]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: npm
-      - uses: jcs090218/setup-emacs@master
+      - uses: jcs090218/setup-emacs@a5b1cbb1af335d2e7bef99c0aa6e02cdad229182 # master
         with:
           version: ${{ matrix.emacs-version }}
-      - uses: emacs-eldev/setup-eldev@v1.5
+      - uses: emacs-eldev/setup-eldev@66eef997fb15bde4364c00acd4ee459f8be9f8b4 # v1.5
       - run: npm ci
       - name: Cache Eldev dependencies
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.eldev
           key: ${{ runner.os }}-eldev-${{ matrix.emacs-version }}-${{ hashFiles('Eldev') }}
@@ -74,7 +74,7 @@ jobs:
       - name: Get Playwright version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_ENV
       - name: Cache Playwright browsers
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: /opt/pw-browsers
@@ -96,8 +96,8 @@ jobs:
     outputs:
       should_run: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dorny/paths-filter@v4.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -112,18 +112,18 @@ jobs:
     if: always() && needs.check-screenshots.outputs.should_run == 'true' && needs.test.result == 'success' && needs.test-elisp.result == 'success' && needs.test-e2e.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: npm
-      - uses: jcs090218/setup-emacs@master
+      - uses: jcs090218/setup-emacs@a5b1cbb1af335d2e7bef99c0aa6e02cdad229182 # master
         with:
           version: "29.4"
-      - uses: emacs-eldev/setup-eldev@v1.5
+      - uses: emacs-eldev/setup-eldev@66eef997fb15bde4364c00acd4ee459f8be9f8b4 # v1.5
       - run: npm ci
       - name: Cache Eldev dependencies
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.eldev
           key: ${{ runner.os }}-eldev-29.4-${{ hashFiles('Eldev') }}
@@ -133,7 +133,7 @@ jobs:
       - name: Get Playwright version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_ENV
       - name: Cache Playwright browsers
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: /opt/pw-browsers
@@ -149,13 +149,13 @@ jobs:
       - run: npm run screenshots
       - name: Upload screenshots artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: screenshots
           path: docs/screenshots/
       - name: Create Pull Request for updated screenshots
         if: github.event_name == 'push'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: "chore: update README screenshots"
           title: "chore: update README screenshots"


### PR DESCRIPTION
Pin GitHub Actions versions to SHA-1

This PR replaces all version tags in `.github/workflows/test.yaml` with exact SHA-1 commit hashes, per user request. The original version tags have been retained as comments.

---
*PR created automatically by Jules for task [5797363451989263355](https://jules.google.com/task/5797363451989263355) started by @yewton*