### PR TITLE
ci: retry e2e tests on failure using nick-fields/retry

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,12 @@ jobs:
       - name: Install Playwright dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
-      - run: npm run test:e2e
+      - name: Run E2E tests
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: npm run test:e2e
 
   check-screenshots:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replaced the `run: npm run test:e2e` action step with `nick-fields/retry` to auto-retry flakiness. Pinned to the v4 commit hash `ad984534de44a9489a53aefd81eb77f87c70dc60` as requested.

---
*PR created automatically by Jules for task [7664615820235979966](https://jules.google.com/task/7664615820235979966) started by @yewton*