### PR TITLE
chore: remove local npm dependency via build branch deployment

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -1,0 +1,60 @@
+name: Build and Push
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Checkout build branch and merge main
+        run: |
+          # If 'build' branch doesn't exist, create it as an orphan branch
+          if ! git ls-remote --exit-code --heads origin build; then
+            git checkout --orphan build
+            git reset --hard
+            git commit --allow-empty -m "Initial commit for build branch"
+            git push origin build
+          fi
+
+          # Checkout build branch and merge main
+          git checkout build
+          git merge main --no-edit || (git checkout --ours . && git add . && git commit -m "Resolve merge conflicts by favoring main")
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Commit and push changes
+        run: |
+          # Force add dist directory (even if ignored by .gitignore)
+          git add -f packages/frontend/dist/
+
+          # Commit if there are changes
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: build frontend dist [skip ci]"
+            git push origin build
+          else
+            echo "No changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ has been modified to better support org-node. Many thanks to Masaya Taniguchi fo
 ### Manual
 
 ```
-git clone https://github.com/yewton/org-node-ui-lite.git
-cd org-node-ui-lite
-cd packages/frontend && npm install && npm run build && cd ../..
+git clone -b build https://github.com/yewton/org-node-ui-lite.git
 ```
 
 Add to `init.el`:
@@ -65,6 +63,7 @@ Open <http://localhost:5174/index.html>.
 ;; Example with straight.el
 (straight-use-package
  '(org-node-ui-lite :host github :repo "yewton/org-node-ui-lite"
+                    :branch "build"
                     :files ("org-node-ui-lite.el" "packages/frontend/dist")))
 
 (require 'org-node-ui-lite)

--- a/org-node-ui-lite.el
+++ b/org-node-ui-lite.el
@@ -24,7 +24,7 @@
 ;;
 ;; INTERACTIVE COMMANDS
 ;;   M-x org-node-ui-lite-select-current
-;;       Select the org-node at point in the WebUI regardless of follow-mode.
+;;       Select the org-node at point in the WebUI regardless of `follow-mode'.
 ;;
 ;; QUICK START
 ;;   In init.el:
@@ -152,7 +152,7 @@ The front-end uses this to detect explicit selection requests.")
 ;;;###autoload
 (defun org-node-ui-lite-select-current ()
   "Select the org-node at point in the WebUI.
-Works regardless of whether follow-mode is enabled in the browser."
+Works regardless of whether `follow-mode' is enabled in the browser."
   (interactive)
   (let ((id (when (derived-mode-p 'org-mode)
               (ignore-errors (org-entry-get-with-inheritance "ID")))))
@@ -219,9 +219,6 @@ Works regardless of whether follow-mode is enabled in the browser."
 
 ;;;; Setup helpers
 
-(defvar org-node-ui-lite--build-process nil
-  "Live `npm run build' process, or nil when no build is in progress.")
-
 (defun org-node-ui-lite--dist-p ()
   "Return non-nil when the compiled front-end exists."
   (file-exists-p
@@ -253,32 +250,20 @@ Works regardless of whether follow-mode is enabled in the browser."
   "Global minor mode that serves the org-node-ui-lite graph browser.
 
 On first enable, checks whether the front-end has been compiled.
-If the `dist/' directory is missing and `npm' is available the build
-runs automatically in the background.  When `npm' cannot be found a
-`user-error' is raised with manual build instructions."
+If the `dist/' directory is missing, a `user-error' is raised
+instructing the user to use the `build' branch."
   :global t
   :group 'org-node-ui-lite
   (cond
    (org-node-ui-lite-mode
-    ;; Abort any stale build from a previous enable attempt.
-    (when (process-live-p org-node-ui-lite--build-process)
-      (kill-process org-node-ui-lite--build-process)
-      (setq org-node-ui-lite--build-process nil))
     (condition-case err
         (progn
           (add-hook 'post-command-hook #'org-node-ui-lite--track-current-node)
           (org-node-ui-lite--check-prerequisites)
           (if (org-node-ui-lite--dist-p)
               (org-node-ui-lite--start-server)
-            ;; Front-end not built yet — try to build it automatically.
-            (let* ((root (file-name-directory org-node-ui-lite--this-file))
-                   (npm  (executable-find "npm")))
-              (if npm
-                  (org-node-ui-lite--build-and-start npm root)
-                (user-error
-                 "org-node-ui-lite: front-end not built and `npm' not found; \
-build manually: cd %s && npm install && npm run build"
-                 root)))))
+            (user-error
+             "Org-node-ui-lite: front-end not built.  Please install from the `build' branch")))
       (error
        (org-node-ui-lite-mode -1)
        (signal (car err) (cdr err)))))
@@ -286,49 +271,8 @@ build manually: cd %s && npm install && npm run build"
     (remove-hook 'post-command-hook #'org-node-ui-lite--track-current-node)
     (setq org-node-ui-lite--current-node-id nil
           org-node-ui-lite--explicit-seq 0)
-    (when (process-live-p org-node-ui-lite--build-process)
-      (kill-process org-node-ui-lite--build-process)
-      (setq org-node-ui-lite--build-process nil))
     (httpd-stop)
     (message "org-node-ui-lite stopped"))))
-
-(defun org-node-ui-lite--build-and-start (npm repo-root)
-  "Run npm install (if needed) and npm run build asynchronously.
-NPM is the absolute path to the npm executable.  REPO-ROOT is the
-top-level directory of the org-node-ui-lite checkout.
-On success the HTTP server is started; on failure the mode is disabled
-and the build output is shown."
-  (let* ((has-modules (file-directory-p
-                       (expand-file-name "node_modules" repo-root)))
-         (npm*   (shell-quote-argument npm))
-         (sh-cmd (if has-modules
-                     (format "%s --prefix packages/frontend run build" npm*)
-                   (format "%s install && %s --prefix packages/frontend run build"
-                           npm* npm*)))
-         (buf (get-buffer-create "*org-node-ui-lite-build*")))
-    (with-current-buffer buf (erase-buffer))
-    (message "org-node-ui-lite: %s front-end (this may take a minute)…"
-             (if has-modules "Building" "Installing dependencies and building"))
-    (setq org-node-ui-lite--build-process
-          (let ((default-directory repo-root))
-            (make-process
-             :name "org-node-ui-lite-build"
-             :buffer buf
-             :noquery t
-             :command (list shell-file-name shell-command-switch sh-cmd)
-             :sentinel
-             (lambda (_proc event)
-               (setq org-node-ui-lite--build-process nil)
-               (if (string-match-p "finished" event)
-                   (progn
-                     (message "org-node-ui-lite: Build complete.")
-                     ;; Only start if the user hasn't disabled the mode meanwhile.
-                     (when org-node-ui-lite-mode
-                       (org-node-ui-lite--start-server)))
-                 (org-node-ui-lite-mode -1)
-                 (display-buffer (get-buffer "*org-node-ui-lite-build*"))
-                 (message (concat "org-node-ui-lite: Build failed — "
-                                  "see buffer *org-node-ui-lite-build*")))))))))
 
 (provide 'org-node-ui-lite)
 ;;; org-node-ui-lite.el ends here

--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+#dist
 dist-ssr
 *.local
 

--- a/test/org-node-ui-lite-test.el
+++ b/test/org-node-ui-lite-test.el
@@ -176,17 +176,6 @@
       (should (string= "existing-id" org-node-ui-lite--current-node-id))
       (should (= 3 org-node-ui-lite--explicit-seq)))))
 
-;;;; org-node-ui-lite--build-and-start
-
-(ert-deftest org-node-ui-lite--build-and-start/process-runs-in-repo-root ()
-  "npm process must start in repo-root regardless of the caller's directory."
-  (let (proc-dir)
-    (cl-letf (((symbol-function 'make-process)
-               (lambda (&rest _) (setq proc-dir default-directory) nil))
-              ((symbol-function 'file-directory-p) (lambda (_) nil)))
-      (let ((default-directory "/unrelated/"))
-        (org-node-ui-lite--build-and-start "/usr/bin/npm" "/repo/root/")))
-    (should (string= "/repo/root/" proc-dir))))
 
 (provide 'org-node-ui-lite-test)
 ;;; org-node-ui-lite-test.el ends here


### PR DESCRIPTION
This PR updates the distribution mechanism to avoid relying on a local `npm` build logic inside Emacs Elisp.

- **`org-node-ui-lite.el`:** Removed the `org-node-ui-lite--build-and-start` process that automatically invoked npm if `dist/` was missing. The mode will now throw a `user-error` telling the user to use the `build` branch instead.
- **`README.md`**: Updated installation instructions to clone from the `build` branch.
- **`.github/workflows/build-branch.yaml`**: Added a new workflow that triggers on pushes to `main`. It checks out the repository, handles merging `main` into the `build` branch, runs `npm ci` and `npm run build`, forcefully un-ignores `dist` from git, and commits the built artifacts directly to `build`.

---
*PR created automatically by Jules for task [8654808309808428092](https://jules.google.com/task/8654808309808428092) started by @yewton*