### PR TITLE
feat(graph): add link distance and collision radius controls for 2D force graph

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,7 @@
 		"bootstrap": "^5.3.7",
 		"bootstrap-icons": "^1.13.1",
 		"cytoscape": "^3.32.0",
+		"d3-force": "^3.0.0",
 		"force-graph": "^1.50.1",
 		"openapi-fetch": "^0.14.0",
 		"react": "^19.1.1",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -22,6 +22,8 @@ function App() {
 		labelScale,
 		showLabels,
 		chargeStrength,
+		linkDistance,
+		collisionRadius,
 		followEmacs,
 		settingsOpen,
 		detailsOpen,
@@ -40,6 +42,8 @@ function App() {
 		setLabelScale,
 		setShowLabels,
 		setChargeStrength,
+		setLinkDistance,
+		setCollisionRadius,
 	} = useGraphManager({
 		theme,
 		renderer,
@@ -48,6 +52,8 @@ function App() {
 		labelScale,
 		showLabels,
 		chargeStrength,
+		linkDistance,
+		collisionRadius,
 	});
 
 	useEmacsSync(openNodeAction, followEmacs);
@@ -120,6 +126,22 @@ function App() {
 		[setChargeStrength, dispatch],
 	);
 
+	const handleLinkDistanceChange = useCallback(
+		(d: number) => {
+			void setLinkDistance(d);
+			dispatch({ type: "SET_STATE", payload: { linkDistance: d } });
+		},
+		[setLinkDistance, dispatch],
+	);
+
+	const handleCollisionRadiusChange = useCallback(
+		(r: number) => {
+			void setCollisionRadius(r);
+			dispatch({ type: "SET_STATE", payload: { collisionRadius: r } });
+		},
+		[setCollisionRadius, dispatch],
+	);
+
 	const handleFollowEmacsChange = useCallback(
 		(follow: boolean) => {
 			dispatch({ type: "SET_STATE", payload: { followEmacs: follow } });
@@ -144,6 +166,8 @@ function App() {
 				labelScale={labelScale}
 				showLabels={showLabels}
 				chargeStrength={chargeStrength}
+				linkDistance={linkDistance}
+				collisionRadius={collisionRadius}
 				followEmacs={followEmacs}
 				onThemeChange={handleThemeChange}
 				onRendererChange={handleRendererChange}
@@ -152,6 +176,8 @@ function App() {
 				onLabelScaleChange={handleLabelScaleChange}
 				onShowLabelsChange={handleShowLabelsChange}
 				onChargeStrengthChange={handleChargeStrengthChange}
+				onLinkDistanceChange={handleLinkDistanceChange}
+				onCollisionRadiusChange={handleCollisionRadiusChange}
 				onFollowEmacsChange={handleFollowEmacsChange}
 				onClose={() => dispatch({ type: "TOGGLE_SETTINGS" })}
 			/>

--- a/packages/frontend/src/components/SettingsPanel.tsx
+++ b/packages/frontend/src/components/SettingsPanel.tsx
@@ -22,6 +22,8 @@ interface SettingsPanelProps {
 	labelScale: number;
 	showLabels: boolean;
 	chargeStrength: number;
+	linkDistance: number;
+	collisionRadius: number;
 	followEmacs: boolean;
 	onThemeChange: (theme: Theme) => void;
 	onRendererChange: (renderer: Renderer) => void;
@@ -30,6 +32,8 @@ interface SettingsPanelProps {
 	onLabelScaleChange: (scale: number) => void;
 	onShowLabelsChange: (show: boolean) => void;
 	onChargeStrengthChange: (strength: number) => void;
+	onLinkDistanceChange: (distance: number) => void;
+	onCollisionRadiusChange: (radius: number) => void;
 	onFollowEmacsChange: (follow: boolean) => void;
 	onClose: () => void;
 }
@@ -46,6 +50,8 @@ export function SettingsPanel({
 	labelScale,
 	showLabels,
 	chargeStrength,
+	linkDistance,
+	collisionRadius,
 	followEmacs,
 	onThemeChange,
 	onRendererChange,
@@ -54,6 +60,8 @@ export function SettingsPanel({
 	onLabelScaleChange,
 	onShowLabelsChange,
 	onChargeStrengthChange,
+	onLinkDistanceChange,
+	onCollisionRadiusChange,
 	onFollowEmacsChange,
 	onClose,
 }: SettingsPanelProps) {
@@ -155,6 +163,27 @@ export function SettingsPanel({
 						max={500}
 						step={10}
 						onChange={(v) => onChargeStrengthChange(-v)}
+					/>
+				</When>
+
+				<When condition={renderer === "force-graph"}>
+					<RangeSlider
+						label="Link distance"
+						value={linkDistance}
+						min={20}
+						max={200}
+						step={10}
+						onChange={onLinkDistanceChange}
+						unit="px"
+					/>
+					<RangeSlider
+						label="Collision"
+						value={collisionRadius}
+						min={0}
+						max={50}
+						step={1}
+						onChange={onCollisionRadiusChange}
+						unit="px"
 					/>
 				</When>
 			</div>

--- a/packages/frontend/src/graph/graph-types.ts
+++ b/packages/frontend/src/graph/graph-types.ts
@@ -57,4 +57,6 @@ export type RendererFunction = (
 	labelScale: number,
 	showLabels: boolean,
 	chargeStrength: number,
+	linkDistance: number,
+	collisionRadius: number,
 ) => GraphInstance;

--- a/packages/frontend/src/graph/graph.ts
+++ b/packages/frontend/src/graph/graph.ts
@@ -73,6 +73,8 @@ export async function drawGraph(
 	labelScale: number,
 	showLabels: boolean,
 	chargeStrength: number,
+	linkDistance: number,
+	collisionRadius: number,
 ): Promise<GraphInstance> {
 	const [{ nodes, edges }, rendererMod] = await Promise.all([
 		fetchGraphData(),
@@ -89,6 +91,8 @@ export async function drawGraph(
 		labelScale,
 		showLabels,
 		chargeStrength,
+		linkDistance,
+		collisionRadius,
 	);
 }
 

--- a/packages/frontend/src/graph/renderers/cytoscape.ts
+++ b/packages/frontend/src/graph/renderers/cytoscape.ts
@@ -32,6 +32,8 @@ const renderCytoscape: RendererFunction = (
 	labelScale: number,
 	showLabels: boolean,
 	_chargeStrength: number,
+	_linkDistance: number,
+	_collisionRadius: number,
 ): GraphInstance => {
 	const elements = [
 		...nodes.map((n) => ({ data: n })),

--- a/packages/frontend/src/graph/renderers/force-graph-3d.ts
+++ b/packages/frontend/src/graph/renderers/force-graph-3d.ts
@@ -63,6 +63,8 @@ const renderForceGraph3D: RendererFunction = (
 	labelScale: number,
 	showLabels: boolean,
 	_chargeStrength: number,
+	_linkDistance: number,
+	_collisionRadius: number,
 ): GraphInstance => {
 	void labelScale;
 	void showLabels;

--- a/packages/frontend/src/graph/renderers/force-graph.ts
+++ b/packages/frontend/src/graph/renderers/force-graph.ts
@@ -1,3 +1,4 @@
+import { forceCollide } from "d3-force";
 import type ForceGraph from "force-graph";
 import ForceGraphCtor from "force-graph";
 import { getCssVariable } from "../../utils/style.ts";
@@ -32,6 +33,8 @@ const renderForceGraph: RendererFunction = (
 	labelScale: number,
 	showLabels: boolean,
 	chargeStrength: number,
+	linkDistance: number,
+	collisionRadius: number,
 ): GraphInstance => {
 	const radius = nodeSize / 2;
 	const area = Math.PI * radius * radius;
@@ -47,6 +50,8 @@ const renderForceGraph: RendererFunction = (
 		.linkColor("color")
 		.linkWidth(2)
 		.d3Force("charge", fg.d3Force("charge")?.strength(chargeStrength) ?? null)
+		.d3Force("link", fg.d3Force("link")?.distance(linkDistance) ?? null)
+		.d3Force("collide", forceCollide(collisionRadius))
 		.graphData({ nodes: fgNodes, links: edges });
 
 	if (showLabels) {

--- a/packages/frontend/src/hooks/useGraphManager.ts
+++ b/packages/frontend/src/hooks/useGraphManager.ts
@@ -23,6 +23,8 @@ interface GraphConfig {
 	labelScale: number;
 	showLabels: boolean;
 	chargeStrength: number;
+	linkDistance: number;
+	collisionRadius: number;
 }
 
 interface UseGraphManagerProps extends GraphConfig {
@@ -40,6 +42,8 @@ export function useGraphManager(initialConfig: UseGraphManagerProps) {
 		labelScale: initialConfig.labelScale,
 		showLabels: initialConfig.showLabels,
 		chargeStrength: initialConfig.chargeStrength,
+		linkDistance: initialConfig.linkDistance,
+		collisionRadius: initialConfig.collisionRadius,
 	});
 	const themeRef = useRef<Theme>(initialConfig.theme);
 
@@ -99,6 +103,8 @@ export function useGraphManager(initialConfig: UseGraphManagerProps) {
 			configRef.current.labelScale,
 			configRef.current.showLabels,
 			configRef.current.chargeStrength,
+			configRef.current.linkDistance,
+			configRef.current.collisionRadius,
 		);
 		bindGraphEvents();
 	}, [bindGraphEvents]);
@@ -189,6 +195,22 @@ export function useGraphManager(initialConfig: UseGraphManagerProps) {
 		[refreshGraph],
 	);
 
+	const setLinkDistance = useCallback(
+		async (linkDistance: number) => {
+			configRef.current = { ...configRef.current, linkDistance };
+			await refreshGraph();
+		},
+		[refreshGraph],
+	);
+
+	const setCollisionRadius = useCallback(
+		async (collisionRadius: number) => {
+			configRef.current = { ...configRef.current, collisionRadius };
+			await refreshGraph();
+		},
+		[refreshGraph],
+	);
+
 	return {
 		graphRef,
 		openNodeAction,
@@ -201,6 +223,8 @@ export function useGraphManager(initialConfig: UseGraphManagerProps) {
 		setLabelScale,
 		setShowLabels,
 		setChargeStrength,
+		setLinkDistance,
+		setCollisionRadius,
 		refreshGraph,
 	};
 }

--- a/packages/frontend/src/store/reducer.ts
+++ b/packages/frontend/src/store/reducer.ts
@@ -11,6 +11,8 @@ export interface UiState {
 	labelScale: number;
 	showLabels: boolean;
 	chargeStrength: number;
+	linkDistance: number;
+	collisionRadius: number;
 	followEmacs: boolean;
 	settingsOpen: boolean;
 	detailsOpen: boolean;
@@ -35,6 +37,8 @@ export const initialState: UiState = {
 	labelScale: 0.5,
 	showLabels: true,
 	chargeStrength: -120,
+	linkDistance: 30,
+	collisionRadius: 0,
 	followEmacs: false,
 	settingsOpen: false,
 	detailsOpen: false,
@@ -49,6 +53,8 @@ export const persistedKeys: (keyof UiState)[] = [
 	"labelScale",
 	"showLabels",
 	"chargeStrength",
+	"linkDistance",
+	"collisionRadius",
 	"followEmacs",
 ];
 

--- a/packages/frontend/test/SettingsPanel.test.tsx
+++ b/packages/frontend/test/SettingsPanel.test.tsx
@@ -21,6 +21,8 @@ describe("SettingsPanel", () => {
 				labelScale={1}
 				showLabels={true}
 				chargeStrength={-120}
+				linkDistance={30}
+				collisionRadius={0}
 				followEmacs={false}
 				onThemeChange={handleChange}
 				onRendererChange={handleChange}
@@ -29,6 +31,8 @@ describe("SettingsPanel", () => {
 				onLabelScaleChange={handleChange}
 				onShowLabelsChange={handleChange}
 				onChargeStrengthChange={handleChange}
+				onLinkDistanceChange={handleChange}
+				onCollisionRadiusChange={handleChange}
 				onFollowEmacsChange={handleChange}
 				onClose={handleClose}
 			/>,

--- a/packages/frontend/test/fixtures/sampleNodes.test.tsx
+++ b/packages/frontend/test/fixtures/sampleNodes.test.tsx
@@ -176,6 +176,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		const nodesArg = mockForceGraphRenderer.mock.calls[0]?.[0] as unknown[];
@@ -193,6 +195,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		const nodesArg = mockForceGraphRenderer.mock.calls[0]?.[0] as Array<{
@@ -218,6 +222,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		const nodesArg = mockForceGraphRenderer.mock.calls[0]?.[0] as Array<{
@@ -243,6 +249,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		const edgesArg = mockForceGraphRenderer.mock.calls[0]?.[1] as unknown[];
@@ -260,6 +268,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		const edgesArg = mockForceGraphRenderer.mock.calls[0]?.[1] as Array<{
@@ -302,6 +312,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		// Two orphan edges must be stripped; only 31 valid ones remain
@@ -320,6 +332,8 @@ describe("Graph module with 30-node dataset", () => {
 			0.5,
 			true,
 			-120,
+			30,
+			0,
 		);
 
 		expect(result).toEqual({ type: "force-graph" });

--- a/packages/frontend/test/graph/graph.test.ts
+++ b/packages/frontend/test/graph/graph.test.ts
@@ -78,6 +78,8 @@ describe("Graph Module", () => {
 				1,
 				true,
 				-120,
+				30,
+				0,
 			);
 
 			expect(mockGET).toHaveBeenCalledWith("api/graph.json");
@@ -103,6 +105,8 @@ describe("Graph Module", () => {
 				1,
 				true,
 				-120,
+				30,
+				0,
 			);
 		});
 
@@ -126,6 +130,8 @@ describe("Graph Module", () => {
 					1,
 					true,
 					-120,
+					30,
+					0,
 				),
 			).rejects.toThrow("API error: Network error");
 		});
@@ -157,6 +163,8 @@ describe("Graph Module", () => {
 				1.2,
 				false,
 				-120,
+				30,
+				0,
 			);
 
 			expect(mockCytoscapeRenderer).toHaveBeenCalled();
@@ -176,6 +184,8 @@ describe("Graph Module", () => {
 				0.8,
 				true,
 				-120,
+				30,
+				0,
 			);
 
 			expect(mockForceGraphRenderer).toHaveBeenCalled();
@@ -195,6 +205,8 @@ describe("Graph Module", () => {
 				1.5,
 				true,
 				-120,
+				30,
+				0,
 			);
 
 			expect(mock3DForceGraphRenderer).toHaveBeenCalled();
@@ -217,6 +229,8 @@ describe("Graph Module", () => {
 				1,
 				true,
 				-120,
+				30,
+				0,
 			);
 
 			expect(mockCytoscapeRenderer).toHaveBeenCalledWith(
@@ -229,6 +243,8 @@ describe("Graph Module", () => {
 				1,
 				true,
 				-120,
+				30,
+				0,
 			);
 		});
 	});

--- a/packages/frontend/test/hooks/useGraphManager.test.tsx
+++ b/packages/frontend/test/hooks/useGraphManager.test.tsx
@@ -44,6 +44,8 @@ describe("useGraphManager Hook", () => {
 		labelScale: 1,
 		showLabels: true,
 		chargeStrength: -120,
+		linkDistance: 30,
+		collisionRadius: 0,
 	};
 
 	beforeEach(async () => {


### PR DESCRIPTION
## Summary

- Add **Link distance** slider (20–200 px, default 30) to the Settings panel; applies `d3Force("link").distance()` on the 2D force-graph renderer, spreading clusters proportionally to edge count.
- Add **Collision** slider (0–50 px, default 0) to the Settings panel; adds `forceCollide(radius)` so overlapping nodes are physically pushed apart without relying solely on charge repulsion.
- Both values are persisted to `localStorage` via the existing `persistedKeys` mechanism.
- The 3D force-graph and Cytoscape renderers accept the new arguments but leave them unused (consistent with the existing `_chargeStrength` pattern).
- Add `d3-force` as an explicit dependency in `packages/frontend/package.json` (was a transitive dep via `force-graph`).

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run check` passes
- [ ] `npm test` passes (28 files, 236 tests)
- [ ] `eldev --packaged compile --warnings-as-errors` passes
- [ ] `eldev test` passes (18/18)
- [ ] Manually open Settings panel with Force Graph (2D) selected → two new sliders appear
- [ ] Manually verify Link distance slider spreads cluster nodes apart as value increases
- [ ] Manually verify Collision slider prevents node overlap when value > node radius
- [ ] Switching to 3D or Cytoscape renderer hides the new sliders
- [ ] Page reload restores slider values from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)